### PR TITLE
Fix permissions for ripgrep (rg) - "Error: spawn EACCES"

### DIFF
--- a/app-editors/visual-studio-code-bin/visual-studio-code-bin-1.31.0.ebuild
+++ b/app-editors/visual-studio-code-bin/visual-studio-code-bin-1.31.0.ebuild
@@ -38,6 +38,7 @@ src_install(){
 	make_desktop_entry "${PN}" "Visual Studio Code" "${PN}" "Development;IDE"
 	doicon "${FILESDIR}/${PN}.png"
 	fperms +x "/opt/${PN}/code"
+	find /opt/${PN} -name rg -exec chmod a+x {} \;
 	fperms +x "/opt/${PN}/libnode.so"
 	fperms +x "/opt/${PN}/libffmpeg.so"
 	insinto "/usr/share/licenses/${PN}"


### PR DESCRIPTION
Others have had this problem:

https://github.com/Microsoft/vscode/issues/25848

This patch fixed it for me.